### PR TITLE
Wise (UK OBIE) adapter: AIS read path + signed Hybrid Flow

### DIFF
--- a/docs/14-semantic-compression-and-the-connector-layer.md
+++ b/docs/14-semantic-compression-and-the-connector-layer.md
@@ -111,6 +111,37 @@ Mechanics expected to be **genuinely bank-specific** → stay as custom handlers
   (`ReadAccountsBasic`, `ReadBalances`, `ReadTransactions*`, …) and a consent
   `Status` lifecycle (`AwaitingAuthorisation` → authorised).
 
+## Findings after the Wise AIS path (slices 1–3b)
+
+Both predictions held — now with two concrete occurrences (LHV + Wise):
+
+**Confirmed identical → extract on connector #3** (the operation-envelope, the
+mapper plumbing, and the status/SSRF mechanics are the same shape, only the
+vocabulary/source-paths differ):
+
+- the operation envelope (`headers → optional headers → @http.request →
+  guard_response! → Mapper`) — `wise/adapter.rb` reads line-for-line like
+  `lhv/adapter.rb`;
+- `evidence(response, redact:)`, redacting token bodies — copied verbatim;
+- group-by-currency + available/booked `pick_balance` classification;
+- the typed, redaction-safe `ProviderError` rejection (`tppMessages` vs
+  `Errors[]` — same logic, different key);
+- the status table + "unknown never collapses to valid";
+- the origin-pinned `absolute()` SSRF guard (only the base path differs).
+
+**Confirmed genuinely bank-specific → stays a pluggable handler** (these are the
+*parameters* a future table must take, not absorb):
+
+- auth strategy — Wise's two-token Hybrid Flow vs LHV's single OAuth token;
+- request-object signing — `security/jws` (PS256) + the OBSeal key, which LHV
+  never needs;
+- the payload envelope — OBIE `Data` vs flat Berlin Group;
+- the consent access model — `Permissions[]` vs `availableAccounts`.
+
+So the third connector should trigger extracting a shared **operation table +
+mapper table + status table**, with **auth strategy left pluggable**. Not yet —
+two occurrences, per ADR-0004's three-times rule.
+
 ## References
 
 - OMeta — [VPRI TR-2007-003 (PDF)](https://tinlizzie.org/VPRIPapers/tr2007003_ometa.pdf),

--- a/lib/navesti.rb
+++ b/lib/navesti.rb
@@ -44,11 +44,12 @@ require_relative "navesti/providers/lhv/dialect"
 require_relative "navesti/providers/lhv/mappers"
 require_relative "navesti/providers/lhv/adapter"
 
-# Wise (UK OBIE) — config + dialect first; mappers/adapter land in later slices
+# Wise (UK OBIE) — a second PSD2 standard alongside LHV's Berlin Group
 # (docs/14-semantic-compression-and-the-connector-layer.md).
 require_relative "navesti/providers/wise/config"
 require_relative "navesti/providers/wise/dialect"
 require_relative "navesti/providers/wise/mappers"
+require_relative "navesti/providers/wise/adapter"
 
 module Navesti
   # Constructs a bank adapter. Credentials and HTTP client are supplied by the
@@ -59,6 +60,8 @@ module Navesti
     case provider.to_sym
     when :lhv
       Providers::LHV::Adapter.new(**kwargs)
+    when :wise
+      Providers::Wise::Adapter.new(**kwargs)
     else
       raise ArgumentError, "unknown provider #{provider.inspect}"
     end

--- a/lib/navesti/providers/wise/adapter.rb
+++ b/lib/navesti/providers/wise/adapter.rb
@@ -1,0 +1,240 @@
+# frozen_string_literal: true
+
+require "json"
+require "uri"
+require "securerandom"
+
+module Navesti
+  module Providers
+    module Wise
+      # The Wise (UK OBIE 3.1.11) adapter: explicit, ordered operations over the
+      # Open Banking AIS interface. Like LHV, there is no flow engine — the
+      # "flow" is the documented calling order, which here is OBIE's two-token
+      # Hybrid Flow:
+      #
+      #   app_token (client_credentials)         -> token to create the consent
+      #   create_consent (Permissions)           -> ConsentId (AwaitingAuthorisation)
+      #   authorize_url (signed JWT Request Obj)  -> (PSU at bank) -> code id_token
+      #   exchange_code (authorization_code)      -> user access + refresh tokens
+      #   accounts / balances / consent_status    -> normalized facts
+      #
+      # What differs from LHV (a different PSD2 standard, by design — docs/14):
+      #   - a client_credentials app token is needed *before* the consent;
+      #   - the authorize step carries a PS256-signed Request Object
+      #     (security/jws) with openbanking_intent_id = ConsentId;
+      #   - the wire shape is the OBIE { "Data": … } envelope (Mappers).
+      #
+      # Stateless: every call takes what it needs; persists nothing.
+      class Adapter
+        attr_reader :config, :credentials
+
+        # The signed Request Object is short-lived: it only has to survive the
+        # browser redirect to the authorize endpoint.
+        REQUEST_OBJECT_TTL = 300 # seconds
+
+        def initialize(credentials:, env: :sandbox, http: HTTP::Client.new, request_id: nil, clock: nil)
+          @credentials = credentials
+          @config = Config.new(env: env)
+          @http = http
+          @request_id = request_id || -> { SecureRandom.uuid }
+          @clock = clock || -> { Time.now.utc }
+        end
+
+        # POST /auth/token (client_credentials) — the app token used to create a
+        # consent. mTLS + client_id in the body bind the cert to the client
+        # (RFC8705). Default AISP scope is "accounts".
+        def app_token(scope: "accounts")
+          token_request(grant_type: "client_credentials", scope: scope)
+        end
+
+        # POST /aisp/account-access-consents — creates an account-access consent
+        # with the requested OBIE permissions, returning a Consent in
+        # AwaitingAuthorisation. The host holds the ConsentId and supplies it to
+        # #authorize_url. No interaction is returned here — the authorize URL is
+        # built + signed by #authorize_url (unlike LHV's _links.scaRedirect).
+        def create_consent(access_token:, permissions: Dialect::DEFAULT_PERMISSIONS)
+          body = { "Data" => { "Permissions" => permissions }, "Risk" => {} }
+          response = @http.request(
+            method: :post,
+            url: config.account_access_consents_url,
+            headers: bearer_headers(access_token, "Content-Type" => "application/json"),
+            body: JSON.generate(body),
+            credentials: credentials
+          )
+          guard_response!(response)
+          Mappers.consent(response)
+        end
+
+        # Builds the Hybrid-Flow authorization redirect. URL construction + JWS
+        # signing only — no HTTP. The Request Object (PS256, OBSeal key) carries
+        # the duplicated params and openbanking_intent_id = consent_id. Returns
+        # an Interaction the host presents; the bank renders login + 2FA + SCA.
+        def authorize_url(consent_id:, redirect_uri:, scope: "openid accounts", state: nil, nonce: nil)
+          request_jwt = sign_request_object(
+            consent_id: consent_id, redirect_uri: redirect_uri, scope: scope, state: state, nonce: nonce
+          )
+          url = config.oauth_authorize_url(
+            client_id: client_id, redirect_uri: redirect_uri, scope: scope,
+            request_jwt: request_jwt, state: state, nonce: nonce
+          )
+          Interaction.new(type: :redirect, url: url, state: state)
+        end
+
+        # POST /auth/token (authorization_code) — exchanges the post-SCA code for
+        # the user access + refresh token pair (scope carries consent-id:<id>).
+        def exchange_code(code:, redirect_uri:)
+          token_request(grant_type: "authorization_code", code: code, redirect_uri: redirect_uri)
+        end
+
+        # POST /auth/token (refresh_token) — mints a fresh access token. The host
+        # owns token lifecycle/storage; Navesti only performs the exchange.
+        def refresh_token(refresh_token:)
+          token_request(grant_type: "refresh_token", refresh_token: refresh_token)
+        end
+
+        # GET /aisp/accounts → [Account]. Uses the user access token.
+        def accounts(access_token:)
+          response = @http.request(
+            method: :get, url: config.accounts_url,
+            headers: bearer_headers(access_token), credentials: credentials
+          )
+          guard_response!(response)
+          Mappers.accounts(response)
+        end
+
+        # GET /aisp/accounts/{id} → Account (or nil if the bank returns none).
+        def account(access_token:, account_id:)
+          response = @http.request(
+            method: :get, url: config.account_url(account_id),
+            headers: bearer_headers(access_token), credentials: credentials
+          )
+          guard_response!(response)
+          Mappers.accounts(response).first
+        end
+
+        # GET /aisp/accounts/{id}/balances → [Balance], one per currency.
+        def balances(access_token:, account_id:)
+          response = @http.request(
+            method: :get, url: config.account_balances_url(account_id),
+            headers: bearer_headers(access_token), credentials: credentials
+          )
+          guard_response!(response)
+          Mappers.balances(response, provider_account_id: account_id)
+        end
+
+        # GET /aisp/account-access-consents/{id} → Consent. Poll after the PSU
+        # completes SCA; status moves AwaitingAuthorisation → Authorised (:valid).
+        def consent_status(access_token:, consent_id:)
+          response = @http.request(
+            method: :get, url: config.account_access_consent_url(consent_id),
+            headers: bearer_headers(access_token), credentials: credentials
+          )
+          guard_response!(response)
+          Mappers.consent_status(response)
+        end
+
+        private
+
+        # The registered OBIE client_id (the cert CN matches it). The host
+        # supplies it as credentials.tpp_id — unlike LHV, it is not the cert's
+        # organizationIdentifier, so we never derive it from the cert here.
+        def client_id
+          @client_id ||= credentials.tpp_id ||
+            raise(CredentialError, "Wise requires credentials.tpp_id set to the registered OBIE client_id")
+        end
+
+        # Shared token-endpoint call: form-encoded body + client_id, mTLS.
+        def token_request(**fields)
+          body = URI.encode_www_form(fields.merge(client_id: client_id))
+          response = @http.request(
+            method: :post,
+            url: config.token_url,
+            headers: base_headers("Content-Type" => "application/x-www-form-urlencoded"),
+            body: body,
+            credentials: credentials
+          )
+          guard_oauth_response!(response)
+          Mappers.token(response)
+        end
+
+        # Builds + PS256-signs the OBIE Request Object. Every URL param is
+        # duplicated inside the JWT (OBIE requirement), and openbanking_intent_id
+        # binds the authorization to this consent. iat/exp come from the injected
+        # clock so the gem stays testable.
+        def sign_request_object(consent_id:, redirect_uri:, scope:, state:, nonce:)
+          now = @clock.call.to_i
+          intent = { "value" => consent_id, "essential" => true }
+          claims = {
+            "iss" => client_id,
+            "aud" => config.audience,
+            "response_type" => "code id_token",
+            "client_id" => client_id,
+            "redirect_uri" => redirect_uri,
+            "scope" => scope,
+            "iat" => now,
+            "exp" => now + REQUEST_OBJECT_TTL,
+            "claims" => {
+              "id_token" => {
+                "openbanking_intent_id" => intent,
+                "acr" => { "essential" => true, "values" => ["urn:openbanking:psd2:sca", "urn:openbanking:psd2:ca"] }
+              },
+              "userinfo" => { "openbanking_intent_id" => intent }
+            }
+          }
+          claims["state"] = state if state
+          claims["nonce"] = nonce if nonce
+
+          Security::JWS.sign_ps256(claims, signing_key_pem: credentials.signing_key_pem, kid: credentials.signing_kid)
+        end
+
+        def base_headers(extra = {})
+          { "x-fapi-interaction-id" => @request_id.call, "Accept" => "application/json" }.merge(extra)
+        end
+
+        def bearer_headers(access_token, extra = {})
+          base_headers("Authorization" => "Bearer #{access_token}").merge(extra)
+        end
+
+        # AIS guard: 401 -> ConsentError (host re-supplies credentials; Navesti
+        # never refreshes). Other failures -> ProviderError.
+        def guard_response!(response)
+          return if response.success?
+
+          raise ConsentError, "Wise rejected the access token (HTTP #{response.status})" if response.status == 401
+
+          raise_provider_error!(response)
+        end
+
+        # OAuth guard: surface the error field rather than masking 401.
+        def guard_oauth_response!(response)
+          return if response.success?
+
+          raise_provider_error!(response)
+        end
+
+        # Raises a typed, redaction-safe ProviderError, preferring an OBIE
+        # Errors[].ErrorCode, then an OAuth `error`, then the top-level Code.
+        def raise_provider_error!(response)
+          body = response.json_or_nil
+          if body.is_a?(Hash)
+            err = Array(body["Errors"]).find { |e| e.is_a?(Hash) && e["ErrorCode"] }
+            if err
+              raise ProviderError.new(
+                "Wise error #{err['ErrorCode']} (HTTP #{response.status})",
+                http_status: response.status, provider_code: err["ErrorCode"]
+              )
+            end
+            if body["error"]
+              raise ProviderError.new(
+                "Wise OAuth error #{body['error']} (HTTP #{response.status})",
+                http_status: response.status, provider_code: body["error"]
+              )
+            end
+          end
+
+          raise ProviderError.new("Wise request failed (HTTP #{response.status})", http_status: response.status)
+        end
+      end
+    end
+  end
+end

--- a/lib/navesti/providers/wise/config.rb
+++ b/lib/navesti/providers/wise/config.rb
@@ -54,6 +54,13 @@ module Navesti
           "#{identity}/openbanking/.well-known/openid-configuration"
         end
 
+        # The `aud` claim for the signed Request Object: the API host origin
+        # (scheme://host, without the /open-banking path), e.g.
+        # https://openbanking.wise-sandbox.com — per the Wise authorize example.
+        def audience
+          api_origin
+        end
+
         # Hybrid Flow authorization endpoint (identity host). `request_jwt` is the
         # signed Request Object carrying the openbanking_intent_id (ConsentId) and
         # the duplicated params; every URL param must also appear inside the JWT.

--- a/spec/navesti/providers/wise/adapter_spec.rb
+++ b/spec/navesti/providers/wise/adapter_spec.rb
@@ -1,0 +1,200 @@
+# frozen_string_literal: true
+
+require "base64"
+require "tempfile"
+require "openssl"
+
+RSpec.describe Navesti::Providers::Wise::Adapter do
+  # One OBSeal keypair for the suite, written to a temp PEM the Credentials can
+  # read (RSA generation is slow; do it once).
+  WISE_SIGNING_KEY = OpenSSL::PKey::RSA.new(2048)
+  _kf = Tempfile.create(["obseal", ".pem"])
+  _kf.write(WISE_SIGNING_KEY.to_pem)
+  _kf.flush
+  WISE_SIGNING_KEY_PATH = _kf.path
+
+  FROZEN_NOW = 1_700_000_000
+
+  def credentials(tpp_id: "ob-dummy-tpp", signing: true)
+    Navesti::Credentials.new(
+      client_cert_path: "c", client_key_path: "k", tpp_id: tpp_id,
+      signing_key_path: signing ? WISE_SIGNING_KEY_PATH : nil,
+      signing_kid: signing ? "kid-1" : nil
+    )
+  end
+
+  def adapter(*responses, creds: credentials)
+    http = FakeHTTPClient.new(*responses)
+    a = described_class.new(
+      credentials: creds, http: http,
+      request_id: -> { "req-fixed" }, clock: -> { Time.at(FROZEN_NOW).utc }
+    )
+    [a, http]
+  end
+
+  def b64url(segment)
+    Base64.urlsafe_decode64(segment + ("=" * ((4 - (segment.length % 4)) % 4)))
+  end
+
+  def jwt_part(jwt, index)
+    JSON.parse(b64url(jwt.split(".")[index]))
+  end
+
+  describe "#app_token" do
+    it "requests a client_credentials app token (form body + client_id, mTLS)" do
+      a, http = adapter(Fixtures.wise_response("token"))
+      token = a.app_token
+
+      expect(token).to be_a(Navesti::Token)
+      expect(token.access_token).to eq("wise-access-token-AAAA")
+      req = http.last_request
+      expect(req[:url]).to eq("https://openbanking.wise-sandbox.com/open-banking/auth/token")
+      expect(req[:headers]["Content-Type"]).to eq("application/x-www-form-urlencoded")
+      body = URI.decode_www_form(req[:body]).to_h
+      expect(body).to include("grant_type" => "client_credentials", "scope" => "accounts", "client_id" => "ob-dummy-tpp")
+    end
+
+    it "raises CredentialError when tpp_id (the OBIE client_id) is not configured" do
+      a, = adapter(creds: credentials(tpp_id: nil))
+      expect { a.app_token }.to raise_error(Navesti::CredentialError, /client_id/)
+    end
+  end
+
+  describe "#create_consent" do
+    it "posts Permissions + Risk with the app token, returning a :received Consent" do
+      a, http = adapter(Fixtures.wise_response("consent_awaiting", status: 201))
+      consent = a.create_consent(access_token: "app-tok", permissions: %w[ReadAccountsBasic ReadBalances])
+
+      expect(consent).to be_a(Navesti::Consent)
+      expect(consent.consent_id).to eq("urn-wise-aac-000111")
+      expect(consent.status).to eq(:received)
+      expect(consent.interaction).to be_nil
+      req = http.last_request
+      expect(req[:url]).to end_with("/v3.1.11/aisp/account-access-consents")
+      expect(req[:headers]["Authorization"]).to eq("Bearer app-tok")
+      body = JSON.parse(req[:body])
+      expect(body["Data"]["Permissions"]).to eq(%w[ReadAccountsBasic ReadBalances])
+      expect(body["Risk"]).to eq({})
+    end
+
+    it "defaults to the balance-reading permission set" do
+      a, http = adapter(Fixtures.wise_response("consent_awaiting", status: 201))
+      a.create_consent(access_token: "t")
+      expect(JSON.parse(http.last_request[:body])["Data"]["Permissions"]).to eq(%w[ReadAccountsBasic ReadBalances])
+    end
+  end
+
+  describe "#authorize_url (signed Hybrid Flow)" do
+    subject(:interaction) do
+      a, = adapter
+      a.authorize_url(consent_id: "123", redirect_uri: "https://ob-dummy-tpp/redirect", state: "st1", nonce: "n1")
+    end
+
+    it "returns a redirect Interaction to the identity authorize endpoint" do
+      expect(interaction).to be_a(Navesti::Interaction)
+      expect(interaction.type).to eq(:redirect)
+      expect(interaction.url).to start_with("https://wise-sandbox.com/openbanking/authorize?")
+      expect(interaction.state).to eq("st1")
+    end
+
+    it "carries a PS256 Request Object with the OBIE claims (intent = ConsentId)" do
+      jwt = URI.decode_www_form(URI.parse(interaction.url).query).to_h.fetch("request")
+      header = jwt_part(jwt, 0)
+      payload = jwt_part(jwt, 1)
+
+      expect(header).to include("alg" => "PS256", "kid" => "kid-1")
+      expect(payload).to include(
+        "iss" => "ob-dummy-tpp", "client_id" => "ob-dummy-tpp",
+        "aud" => "https://openbanking.wise-sandbox.com",
+        "response_type" => "code id_token", "redirect_uri" => "https://ob-dummy-tpp/redirect",
+        "scope" => "openid accounts", "state" => "st1", "nonce" => "n1",
+        "iat" => FROZEN_NOW, "exp" => FROZEN_NOW + 300
+      )
+      expect(payload.dig("claims", "id_token", "openbanking_intent_id", "value")).to eq("123")
+      expect(payload.dig("claims", "userinfo", "openbanking_intent_id", "value")).to eq("123")
+    end
+
+    it "produces a signature the OBSeal public key verifies" do
+      jwt = URI.decode_www_form(URI.parse(interaction.url).query).to_h.fetch("request")
+      head, pay, sig = jwt.split(".")
+      ok = WISE_SIGNING_KEY.verify_pss("SHA256", b64url(sig), "#{head}.#{pay}", salt_length: :digest, mgf1_hash: "SHA256")
+      expect(ok).to be(true)
+    end
+
+    it "raises CredentialError when no signing key is configured" do
+      a, = adapter(creds: credentials(signing: false))
+      expect { a.authorize_url(consent_id: "123", redirect_uri: "https://t/cb") }
+        .to raise_error(Navesti::CredentialError)
+    end
+  end
+
+  describe "#exchange_code" do
+    it "exchanges the code for the user access + refresh token pair" do
+      a, http = adapter(Fixtures.wise_response("token"))
+      token = a.exchange_code(code: "authcode", redirect_uri: "https://ob-dummy-tpp/redirect")
+
+      expect(token.refresh_token).to eq("wise-refresh-token-BBBB")
+      body = URI.decode_www_form(http.last_request[:body]).to_h
+      expect(body).to include(
+        "grant_type" => "authorization_code", "code" => "authcode",
+        "redirect_uri" => "https://ob-dummy-tpp/redirect", "client_id" => "ob-dummy-tpp"
+      )
+    end
+  end
+
+  describe "AIS reads" do
+    it "#accounts lists the consented accounts" do
+      a, http = adapter(Fixtures.wise_response("accounts"))
+      accounts = a.accounts(access_token: "user-tok")
+
+      expect(accounts.map(&:provider_account_id)).to eq(%w[504 777 888])
+      req = http.last_request
+      expect(req[:url]).to end_with("/v3.1.11/aisp/accounts")
+      expect(req[:headers]["Authorization"]).to eq("Bearer user-tok")
+    end
+
+    it "#balances reads per-currency balances for an account" do
+      a, http = adapter(Fixtures.wise_response("account_balances"))
+      balances = a.balances(access_token: "user-tok", account_id: "504")
+
+      expect(balances.map(&:currency)).to contain_exactly("GBP", "EUR")
+      expect(http.last_request[:url]).to end_with("/aisp/accounts/504/balances")
+    end
+
+    it "#consent_status polls the consent resource" do
+      a, http = adapter(Fixtures.wise_response("consent_awaiting"))
+      consent = a.consent_status(access_token: "app-tok", consent_id: "urn-wise-aac-000111")
+
+      expect(consent.status).to eq(:received)
+      expect(http.last_request[:url]).to end_with("/account-access-consents/urn-wise-aac-000111")
+    end
+  end
+
+  describe "error guards" do
+    it "raises ConsentError on a 401" do
+      a, = adapter(FakeHTTPClient.json_response(status: 401, body: {}))
+      expect { a.accounts(access_token: "bad") }.to raise_error(Navesti::ConsentError)
+    end
+
+    it "raises a typed ProviderError from an OBIE Errors[] body" do
+      body = { "Code" => "400 BadRequest", "Errors" => [{ "ErrorCode" => "UK.OBIE.Field.Invalid", "Message" => "bad" }] }
+      a, = adapter(FakeHTTPClient.json_response(status: 400, body: body))
+      expect { a.accounts(access_token: "t") }.to raise_error(Navesti::ProviderError) do |e|
+        expect(e.provider_code).to eq("UK.OBIE.Field.Invalid")
+        expect(e.http_status).to eq(400)
+      end
+    end
+
+    it "surfaces an OAuth error from the token endpoint" do
+      a, = adapter(FakeHTTPClient.json_response(status: 400, body: { "error" => "invalid_client" }))
+      expect { a.app_token }.to raise_error(Navesti::ProviderError) do |e|
+        expect(e.provider_code).to eq("invalid_client")
+      end
+    end
+  end
+
+  it "is constructible via Navesti.adapter(:wise)" do
+    a = Navesti.adapter(:wise, credentials: credentials, env: :sandbox)
+    expect(a).to be_a(described_class)
+  end
+end


### PR DESCRIPTION
Slice 3b — wires the foundation into a working AIS connector:
- providers/wise/adapter — the two-token Hybrid Flow as ordered operations: app_token (client_credentials) → create_consent (Permissions) → authorize_url (PS256-signed Request Object, openbanking_intent_id=ConsentId) → exchange_code → accounts / balances / consent_status. OBIE error guards (Errors[].ErrorCode / OAuth error → typed ProviderError; 401 → ConsentError).
- config: expose audience() (the aud claim = API host origin)
- register Navesti.adapter(:wise)
- docs/14: record the post-3b compression findings — both predictions held; the operation-envelope/mapper/status/SSRF mechanics are now duplicated (LHV + Wise), auth/signing/envelope/consent-model stay bank-specific.

Tests: 216 examples, 0 failures (adapter spec verifies the signed Request Object round-trips against the OBSeal public key).