### PR TITLE
Wise (UK OBIE) PISP: domestic payments (consent → payment → status)

### DIFF
--- a/lib/navesti/providers/wise/adapter.rb
+++ b/lib/navesti/providers/wise/adapter.rb
@@ -133,7 +133,97 @@ module Navesti
           Mappers.consent_status(response)
         end
 
+        # --- PISP (domestic, same-currency) ---
+
+        # POST /pisp/domestic-payment-consents — creates a payment-order consent
+        # carrying the Initiation, returning a Consent in AwaitingAuthorisation
+        # (with a 30-min CutOffDateTime). The host authorizes it via #authorize_url
+        # (scope "openid payments"), exchanges the code, then calls
+        # #create_domestic_payment with the ConsentId. Validated host-side first.
+        def create_domestic_payment_consent(access_token:, order:)
+          Dialect.validate_payment_order!(order)
+          body = { "Data" => { "Initiation" => payment_initiation(order) }, "Risk" => {} }
+          response = @http.request(
+            method: :post,
+            url: config.domestic_payment_consents_url,
+            headers: payment_headers(access_token, order),
+            body: JSON.generate(body),
+            credentials: credentials
+          )
+          guard_response!(response)
+          Mappers.consent(response)
+        end
+
+        # POST /pisp/domestic-payments — submits the payment-order against an
+        # authorized consent. Post-SCA: the returned PaymentSubmission carries a
+        # status (no interaction). The Initiation must match the consent's.
+        def create_domestic_payment(access_token:, consent_id:, order:)
+          Dialect.validate_payment_order!(order)
+          body = { "Data" => { "ConsentId" => consent_id, "Initiation" => payment_initiation(order) }, "Risk" => {} }
+          response = @http.request(
+            method: :post,
+            url: config.domestic_payments_url,
+            headers: payment_headers(access_token, order),
+            body: JSON.generate(body),
+            credentials: credentials
+          )
+          guard_response!(response)
+          Mappers.payment_submission(response, idempotency_key: order.idempotency_key)
+        end
+
+        # GET /pisp/domestic-payments/{id} → PaymentStatus.
+        def domestic_payment_status(access_token:, payment_id:)
+          response = @http.request(
+            method: :get, url: config.domestic_payment_url(payment_id),
+            headers: bearer_headers(access_token), credentials: credentials
+          )
+          guard_response!(response)
+          Mappers.payment_status(response, payment_id: payment_id)
+        end
+
         private
+
+        # OBIE payment endpoints require an x-idempotency-key (≤40 chars). Unlike
+        # LHV's JSON SEPA (no documented idempotency), this is a real bank-side
+        # dedup key — a host idempotency_key flows straight through.
+        def payment_headers(access_token, order)
+          bearer_headers(
+            access_token,
+            "Content-Type" => "application/json",
+            "x-idempotency-key" => idempotency_key_for(order)
+          )
+        end
+
+        # Builds the OBIE domestic Initiation from a Navesti PaymentOrder. The
+        # same Initiation is sent on both the consent and the payment-order, so
+        # they match. Our AccountRef is IBAN-based → UK.OBIE.IBAN scheme.
+        def payment_initiation(order)
+          initiation = {
+            "InstructionIdentification" => instruction_id(order),
+            "EndToEndIdentification" => (order.end_to_end_reference || "NOTPROVIDED").to_s[0, 35],
+            "InstructedAmount" => { "Amount" => order.money.to_decimal_string, "Currency" => order.money.currency },
+            "CreditorAccount" => {
+              "SchemeName" => "UK.OBIE.IBAN",
+              "Identification" => order.creditor.iban,
+              "Name" => order.creditor_name
+            }
+          }
+          remittance = {}
+          remittance["Reference"] = order.end_to_end_reference if order.end_to_end_reference
+          remittance["Unstructured"] = order.remittance_information if order.remittance_information
+          initiation["RemittanceInformation"] = remittance unless remittance.empty?
+          initiation
+        end
+
+        # InstructionIdentification (≤35): derived from the host idempotency key
+        # so a retry reuses it; otherwise a fresh random id.
+        def instruction_id(order)
+          (order.idempotency_key || SecureRandom.hex(16)).to_s[0, 35]
+        end
+
+        def idempotency_key_for(order)
+          order.idempotency_key || SecureRandom.uuid
+        end
 
         # The registered OBIE client_id (the cert CN matches it). The host
         # supplies it as credentials.tpp_id — unlike LHV, it is not the cert's

--- a/lib/navesti/providers/wise/config.rb
+++ b/lib/navesti/providers/wise/config.rb
@@ -104,6 +104,28 @@ module Navesti
           "#{aisp_base}/accounts/#{encode_segment(account_id)}/transactions"
         end
 
+        # --- PISP (v3.1.11) ---
+        #
+        # OBIE payment initiation is a two-resource flow: a payment-order
+        # *consent* (authorized via the same Hybrid Flow as AIS) and then the
+        # payment-order itself, which references the ConsentId.
+
+        def domestic_payment_consents_url
+          "#{pisp_base}/domestic-payment-consents"
+        end
+
+        def domestic_payment_consent_url(consent_id)
+          "#{pisp_base}/domestic-payment-consents/#{encode_segment(consent_id)}"
+        end
+
+        def domestic_payments_url
+          "#{pisp_base}/domestic-payments"
+        end
+
+        def domestic_payment_url(payment_id)
+          "#{pisp_base}/domestic-payments/#{encode_segment(payment_id)}"
+        end
+
         # Resolves a HATEOAS href to a full URL, pinned to the configured API
         # origin AND the `/open-banking` base path (same SSRF guard as LHV's
         # Config#absolute — origin + root-path containment). Bank-supplied or
@@ -125,6 +147,10 @@ module Navesti
 
         def aisp_base
           "#{root}/#{API_VERSION}/aisp"
+        end
+
+        def pisp_base
+          "#{root}/#{API_VERSION}/pisp"
         end
 
         # The scheme://host[:port] of the API root, without the /open-banking

--- a/lib/navesti/providers/wise/dialect.rb
+++ b/lib/navesti/providers/wise/dialect.rb
@@ -55,6 +55,31 @@ module Navesti
         AVAILABLE_BALANCE_TYPES = %w[InterimAvailable ClosingAvailable ForwardAvailable OpeningAvailable Expected].freeze
         BOOKED_BALANCE_TYPES    = %w[InterimBooked ClosingBooked OpeningBooked PreviouslyClosedBooked].freeze
 
+        # OBIE domestic payment-order Status => normalized PaymentStatus facts.
+        #
+        # The double-spend boundary differs from LHV: a Wise payment-order is
+        # POSTed *after* the consent's SCA, so the instruction is already
+        # committed — every status except an explicit Rejected carries
+        # side_effect_possible: true. Do not "simplify" this to false.
+        PAYMENT_STATUS = {
+          "Pending"                           => { status: :pending_execution, safety_status: :pending,   side_effect_possible: true },
+          "AcceptedSettlementInProcess"       => { status: :pending_execution, safety_status: :pending,   side_effect_possible: true },
+          "AcceptedWithoutPosting"            => { status: :pending_execution, safety_status: :pending,   side_effect_possible: true },
+          "AcceptedSettlementCompleted"       => { status: :confirmed,         safety_status: :confirmed, side_effect_possible: true },
+          "AcceptedCreditSettlementCompleted" => { status: :confirmed,         safety_status: :confirmed, side_effect_possible: true },
+          "Rejected"                          => { status: :rejected,          safety_status: :rejected,  side_effect_possible: false }
+        }.freeze
+
+        # Unknown payment codes are never safe by default: unknown + side-effect
+        # possible, never rejected (docs/08 rule 1).
+        UNKNOWN_PAYMENT_STATUS = { status: :unknown, safety_status: :unknown, side_effect_possible: true }.freeze
+
+        # The payment Reference length limit varies by currency (Wise OB docs):
+        # 35 chars for EUR, 18 for GBP. CreditorAccount.Name is capped at 70.
+        REFERENCE_MAX = { "GBP" => 18 }.freeze
+        REFERENCE_DEFAULT_MAX = 35
+        CREDITOR_NAME_MAX = 70
+
         module_function
 
         # Normalizes an OBIE consent Status into a symbol, preserving the raw
@@ -65,6 +90,48 @@ module Navesti
 
         def known_consent_status?(raw_status)
           CONSENT_STATUS.key?(raw_status.to_s)
+        end
+
+        # Normalizes an OBIE payment Status into a PaymentStatus, preserving the
+        # raw code. Unknown codes never collapse to a safe value.
+        def payment_status(raw_status, provider_reference: nil, raw: nil)
+          mapping = PAYMENT_STATUS.fetch(raw_status.to_s, UNKNOWN_PAYMENT_STATUS)
+          PaymentStatus.new(
+            status: mapping[:status],
+            safety_status: mapping[:safety_status],
+            side_effect_possible: mapping[:side_effect_possible],
+            raw_status: raw_status,
+            provider_reference: provider_reference,
+            raw: raw
+          )
+        end
+
+        def known_payment_status?(raw_status)
+          PAYMENT_STATUS.key?(raw_status.to_s)
+        end
+
+        # Deterministic, well-established OBIE limits enforced host-side before
+        # dialing: the per-currency Reference length and the 70-char creditor
+        # name. A domestic payment also needs an IBAN creditor (our AccountRef is
+        # IBAN-based). Charset / sort-code rules are left to the bank.
+        def validate_payment_order!(order)
+          if order.creditor.iban.to_s.empty?
+            raise ValidationError, "Wise domestic payment requires a creditor IBAN"
+          end
+
+          reference = order.end_to_end_reference.to_s
+          unless reference.empty?
+            max = REFERENCE_MAX.fetch(order.money.currency, REFERENCE_DEFAULT_MAX)
+            if reference.length > max
+              raise ValidationError, "Wise payment reference exceeds the #{max}-char limit for #{order.money.currency}"
+            end
+          end
+
+          if order.creditor_name.to_s.length > CREDITOR_NAME_MAX
+            raise ValidationError, "creditor name exceeds the OBIE #{CREDITOR_NAME_MAX}-char limit"
+          end
+
+          order
         end
 
         def available_balance_type?(type)

--- a/lib/navesti/providers/wise/mappers.rb
+++ b/lib/navesti/providers/wise/mappers.rb
@@ -101,7 +101,9 @@ module Navesti
             consent_id: data["ConsentId"],
             status: Dialect.consent_status(data["Status"]),
             raw_status: data["Status"],
-            valid_until: data["ExpirationDateTime"],
+            # AIS consents carry ExpirationDateTime; PIS payment consents carry
+            # a CutOffDateTime (30 min) instead — surface whichever is present.
+            valid_until: data["ExpirationDateTime"] || data["CutOffDateTime"],
             raw: evidence(response)
           )
         end
@@ -128,7 +130,43 @@ module Navesti
           )
         end
 
+        # POST /pisp/domestic-payments → Navesti::PaymentSubmission.
+        #
+        # No interaction here: OBIE runs SCA during the payment-CONSENT
+        # authorization (Hybrid Flow), so by the time the payment-order is
+        # POSTed the instruction is already committed — the submission carries a
+        # status, not a redirect.
+        def payment_submission(response, idempotency_key: nil)
+          data = response.json["Data"] || {}
+          ref = payment_reference(data["DomesticPaymentId"])
+          status = Dialect.payment_status(data["Status"], provider_reference: ref, raw: evidence(response))
+
+          PaymentSubmission.new(
+            status: status,
+            provider_reference: ref,
+            idempotency_key: idempotency_key,
+            submitted_at: Time.now.utc.iso8601,
+            raw: evidence(response)
+          )
+        end
+
+        # GET /pisp/domestic-payments/{id} → Navesti::PaymentStatus.
+        def payment_status(response, payment_id: nil)
+          data = response.json["Data"] || {}
+          Dialect.payment_status(
+            data["Status"],
+            provider_reference: payment_id && payment_reference(payment_id),
+            raw: evidence(response)
+          )
+        end
+
         # --- helpers ---
+
+        def payment_reference(payment_id)
+          return nil if payment_id.to_s.empty?
+
+          ProviderReference.new(value: payment_id, kind: :payment, connector: Config::PROVIDER)
+        end
 
         # First inner Account[] identifier tagged with an IBAN scheme, or nil.
         def iban_for(acc)

--- a/spec/fixtures/wise/domestic_payment_accepted.json
+++ b/spec/fixtures/wise/domestic_payment_accepted.json
@@ -1,0 +1,12 @@
+{
+  "Data": {
+    "DomesticPaymentId": "urn-wise-dp-999",
+    "ConsentId": "urn-wise-dpc-555",
+    "Status": "AcceptedSettlementInProcess",
+    "CreationDateTime": "2026-06-20T10:31:00.000Z",
+    "StatusUpdateDateTime": "2026-06-20T10:31:00.000Z"
+  },
+  "Links": {
+    "Self": "https://openbanking.wise-sandbox.com/open-banking/v3.1.11/pisp/domestic-payments/urn-wise-dp-999"
+  }
+}

--- a/spec/fixtures/wise/domestic_payment_consent_awaiting.json
+++ b/spec/fixtures/wise/domestic_payment_consent_awaiting.json
@@ -1,0 +1,19 @@
+{
+  "Data": {
+    "ConsentId": "urn-wise-dpc-555",
+    "Status": "AwaitingAuthorisation",
+    "CreationDateTime": "2026-06-20T10:00:00.000Z",
+    "CutOffDateTime": "2026-06-20T10:30:00.000Z",
+    "Initiation": {
+      "InstructionIdentification": "webapp-deadbeef",
+      "EndToEndIdentification": "NOTPROVIDED",
+      "InstructedAmount": { "Amount": "10.00", "Currency": "GBP" },
+      "CreditorAccount": {
+        "SchemeName": "UK.OBIE.IBAN",
+        "Identification": "GB00WISE00000000000000",
+        "Name": "Acme Ltd"
+      }
+    }
+  },
+  "Risk": {}
+}

--- a/spec/navesti/providers/wise/adapter_spec.rb
+++ b/spec/navesti/providers/wise/adapter_spec.rb
@@ -193,6 +193,64 @@ RSpec.describe Navesti::Providers::Wise::Adapter do
     end
   end
 
+  describe "PISP (domestic)" do
+    def payment_order(idempotency_key: "webapp-deadbeef", reference: "INV-001")
+      Navesti::PaymentOrder.new(
+        money: Navesti::Money.from_decimal("10.00", "GBP"),
+        debtor: Navesti::AccountRef.iban("GB29NWBK60161331926819"),
+        creditor: Navesti::AccountRef.iban("GB94BARC10201530093459"),
+        creditor_name: "Acme Ltd",
+        remittance_information: "invoice 001",
+        end_to_end_reference: reference,
+        idempotency_key: idempotency_key
+      )
+    end
+
+    it "#create_domestic_payment_consent posts the Initiation with an x-idempotency-key" do
+      a, http = adapter(Fixtures.wise_response("domestic_payment_consent_awaiting", status: 201))
+      consent = a.create_domestic_payment_consent(access_token: "user-tok", order: payment_order)
+
+      expect(consent.consent_id).to eq("urn-wise-dpc-555")
+      expect(consent.status).to eq(:received)
+      req = http.last_request
+      expect(req[:url]).to end_with("/v3.1.11/pisp/domestic-payment-consents")
+      expect(req[:headers]["x-idempotency-key"]).to eq("webapp-deadbeef")
+      init = JSON.parse(req[:body]).dig("Data", "Initiation")
+      expect(init["InstructedAmount"]).to eq("Amount" => "10.00", "Currency" => "GBP")
+      expect(init["CreditorAccount"]).to eq(
+        "SchemeName" => "UK.OBIE.IBAN", "Identification" => "GB94BARC10201530093459", "Name" => "Acme Ltd"
+      )
+      expect(init["RemittanceInformation"]).to eq("Reference" => "INV-001", "Unstructured" => "invoice 001")
+    end
+
+    it "#create_domestic_payment posts the ConsentId + Initiation and maps the submission" do
+      a, http = adapter(Fixtures.wise_response("domestic_payment_accepted", status: 201))
+      sub = a.create_domestic_payment(access_token: "user-tok", consent_id: "urn-wise-dpc-555", order: payment_order)
+
+      expect(sub).to be_a(Navesti::PaymentSubmission)
+      expect(sub.provider_reference.value).to eq("urn-wise-dp-999")
+      expect(sub.status.status).to eq(:pending_execution)
+      expect(sub.side_effect_possible).to be(true)
+      body = JSON.parse(http.last_request[:body])
+      expect(body.dig("Data", "ConsentId")).to eq("urn-wise-dpc-555")
+      expect(http.last_request[:url]).to end_with("/v3.1.11/pisp/domestic-payments")
+    end
+
+    it "#domestic_payment_status reads the order status" do
+      a, http = adapter(Fixtures.wise_response("domestic_payment_accepted"))
+      st = a.domestic_payment_status(access_token: "user-tok", payment_id: "urn-wise-dp-999")
+
+      expect(st.status).to eq(:pending_execution)
+      expect(http.last_request[:url]).to end_with("/pisp/domestic-payments/urn-wise-dp-999")
+    end
+
+    it "validates the order before dialing (rejects an over-length GBP reference)" do
+      a, = adapter
+      expect { a.create_domestic_payment_consent(access_token: "t", order: payment_order(reference: "X" * 19)) }
+        .to raise_error(Navesti::ValidationError, /18-char/)
+    end
+  end
+
   it "is constructible via Navesti.adapter(:wise)" do
     a = Navesti.adapter(:wise, credentials: credentials, env: :sandbox)
     expect(a).to be_a(described_class)

--- a/spec/navesti/providers/wise/dialect_spec.rb
+++ b/spec/navesti/providers/wise/dialect_spec.rb
@@ -58,4 +58,67 @@ RSpec.describe Navesti::Providers::Wise::Dialect do
       expect(described_class::DEFAULT_PERMISSIONS).to eq(%w[ReadAccountsBasic ReadBalances])
     end
   end
+
+  describe ".payment_status" do
+    # The safety contract: a Wise payment-order is POSTed post-SCA, so every
+    # status but Rejected is side_effect_possible: true. Pin it.
+    {
+      "Pending"                           => [:pending_execution, :pending,   true],
+      "AcceptedSettlementInProcess"       => [:pending_execution, :pending,   true],
+      "AcceptedWithoutPosting"            => [:pending_execution, :pending,   true],
+      "AcceptedSettlementCompleted"       => [:confirmed,         :confirmed, true],
+      "AcceptedCreditSettlementCompleted" => [:confirmed,         :confirmed, true],
+      "Rejected"                          => [:rejected,          :rejected,  false]
+    }.each do |raw, (status, safety, side_effect)|
+      it "maps #{raw} -> #{status} / #{safety} / side_effect=#{side_effect}" do
+        result = described_class.payment_status(raw)
+        expect([result.status, result.safety_status, result.side_effect_possible]).to eq([status, safety, side_effect])
+        expect(result.raw_status).to eq(raw)
+      end
+    end
+
+    it "maps an unknown status to :unknown with side_effect true, preserving raw" do
+      result = described_class.payment_status("SomethingNew")
+      expect(result.status).to eq(:unknown)
+      expect(result.side_effect_possible).to be(true)
+      expect(result.raw_status).to eq("SomethingNew")
+    end
+  end
+
+  describe ".validate_payment_order!" do
+    def order(currency: "GBP", reference: "INV-1", creditor_name: "Acme Ltd", creditor_iban: "GB94BARC10201530093459")
+      Navesti::PaymentOrder.new(
+        money: Navesti::Money.from_decimal("10.00", currency),
+        debtor: Navesti::AccountRef.iban("GB29NWBK60161331926819"),
+        creditor: creditor_iban ? Navesti::AccountRef.iban(creditor_iban) : Navesti::AccountRef.new(provider_account_id: "x"),
+        creditor_name: creditor_name,
+        end_to_end_reference: reference
+      )
+    end
+
+    it "accepts a GBP order with an <=18 char reference" do
+      expect { described_class.validate_payment_order!(order(reference: "INV-12345")) }.not_to raise_error
+    end
+
+    it "rejects a GBP reference over 18 chars" do
+      expect { described_class.validate_payment_order!(order(currency: "GBP", reference: "X" * 19)) }
+        .to raise_error(Navesti::ValidationError, /18-char limit for GBP/)
+    end
+
+    it "allows EUR references up to 35 chars, rejecting longer" do
+      expect { described_class.validate_payment_order!(order(currency: "EUR", reference: "X" * 35)) }.not_to raise_error
+      expect { described_class.validate_payment_order!(order(currency: "EUR", reference: "X" * 36)) }
+        .to raise_error(Navesti::ValidationError, /35-char limit for EUR/)
+    end
+
+    it "rejects a creditor name over 70 chars" do
+      expect { described_class.validate_payment_order!(order(creditor_name: "N" * 71)) }
+        .to raise_error(Navesti::ValidationError, /70-char/)
+    end
+
+    it "requires a creditor IBAN" do
+      expect { described_class.validate_payment_order!(order(creditor_iban: nil)) }
+        .to raise_error(Navesti::ValidationError, /creditor IBAN/)
+    end
+  end
 end

--- a/spec/navesti/providers/wise/mappers_spec.rb
+++ b/spec/navesti/providers/wise/mappers_spec.rb
@@ -83,4 +83,38 @@ RSpec.describe Navesti::Providers::Wise::Mappers do
       expect(token.raw[:body]).not_to include("wise-access-token-AAAA")
     end
   end
+
+  describe ".payment_submission" do
+    subject(:submission) do
+      described_class.payment_submission(Fixtures.wise_response("domestic_payment_accepted", status: 201), idempotency_key: "idem-1")
+    end
+
+    it "maps DomesticPaymentId + Status into a PaymentSubmission (no interaction)" do
+      expect(submission).to be_a(Navesti::PaymentSubmission)
+      expect(submission.provider_reference.value).to eq("urn-wise-dp-999")
+      expect(submission.provider_reference.kind).to eq(:payment)
+      expect(submission.status.status).to eq(:pending_execution)
+      expect(submission.side_effect_possible).to be(true)
+      expect(submission.interaction).to be_nil
+      expect(submission.idempotency_key).to eq("idem-1")
+    end
+  end
+
+  describe ".payment_status" do
+    it "maps the order Status, carrying the payment reference" do
+      st = described_class.payment_status(Fixtures.wise_response("domestic_payment_accepted"), payment_id: "urn-wise-dp-999")
+      expect(st).to be_a(Navesti::PaymentStatus)
+      expect(st.status).to eq(:pending_execution)
+      expect(st.provider_reference.value).to eq("urn-wise-dp-999")
+    end
+  end
+
+  describe ".consent (payment consent)" do
+    it "uses CutOffDateTime as valid_until when ExpirationDateTime is absent" do
+      consent = described_class.consent(Fixtures.wise_response("domestic_payment_consent_awaiting", status: 201))
+      expect(consent.consent_id).to eq("urn-wise-dpc-555")
+      expect(consent.status).to eq(:received)
+      expect(consent.valid_until).to eq("2026-06-20T10:30:00.000Z")
+    end
+  end
 end


### PR DESCRIPTION
Adds the OBIE two-resource domestic payment flow on top of the AIS adapter:
- config: domestic-payment-consents + domestic-payments endpoints (pisp_base)
- dialect: OBIE payment-status table (post-SCA, so every status but Rejected is side_effect_possible: true — the double-spend boundary), per-currency Reference length limits (EUR 35 / GBP 18) + creditor-name + IBAN validation
- mappers: payment_submission (DomesticPaymentId/Status, no interaction — SCA already happened at consent authorization), payment_status, and the payment-consent valid_until fallback to CutOffDateTime
- adapter: create_domestic_payment_consent / create_domestic_payment / domestic_payment_status; builds the OBIE Initiation from a PaymentOrder and sends the OBIE x-idempotency-key (a real bank-side dedup key, unlike LHV)
- reuses the existing signed authorize_url/exchange_code (scope "openid payments")

Fixtures + specs; international payments deferred to a follow-up. Tests: 235 examples, 0 failures.